### PR TITLE
Add building selection workflow with floor enhancements

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -95,5 +95,8 @@
         }
       }
     }
+  },
+  "cli": {
+    "analytics": false
   }
 }

--- a/src/app/app.component.css
+++ b/src/app/app.component.css
@@ -23,6 +23,12 @@
   overflow: hidden;
   position: relative;
 }
+.main-content ::ng-deep .p-splitter {
+  border: none;
+}
+.main-content ::ng-deep .p-splitter-gutter {
+  background: transparent;
+}
 .panel {
   padding: 1rem;
   height: 100%;
@@ -39,7 +45,131 @@
   flex-shrink: 0;
 }
 :host ::ng-deep .p-tree {
-  border: none;
-  padding: 0;
   flex-grow: 1;
+}
+
+.building-selection {
+  display: grid;
+  grid-template-columns: minmax(260px, 340px) 1fr;
+  gap: 2.5rem;
+  align-items: center;
+  height: 100%;
+  padding: 2.5rem 3rem;
+  background: radial-gradient(circle at top left, rgba(59,130,246,0.15), transparent 55%),
+              radial-gradient(circle at bottom right, rgba(14,165,233,0.15), transparent 55%);
+}
+
+.selection-copy h2 {
+  font-size: 2rem;
+  color: #0f172a;
+  margin-bottom: 1rem;
+}
+
+.selection-copy p {
+  color: #475569;
+  line-height: 1.6;
+  margin-bottom: 1.5rem;
+}
+
+.selection-copy button {
+  padding: 0.65rem 1.4rem;
+  border-radius: 999px;
+  border: none;
+  background: #e2e8f0;
+  color: #1e293b;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.2s ease, transform 0.2s ease;
+}
+
+.selection-copy button:hover {
+  background: #cbd5f5;
+  transform: translateY(-1px);
+}
+
+.selection-canvas {
+  width: 100%;
+  height: 100%;
+  min-height: 520px;
+  background: #fff;
+  border-radius: 24px;
+  box-shadow: 0 30px 80px rgba(15, 23, 42, 0.15);
+  overflow: hidden;
+}
+
+.panel-section {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  background: rgba(255,255,255,0.92);
+  border-radius: 18px;
+  padding: 1rem;
+  margin-bottom: 1rem;
+  box-shadow: 0 12px 24px rgba(15, 23, 42, 0.08);
+}
+
+.panel-section__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+}
+
+.panel-section__subtitle {
+  margin: 0;
+  color: #64748b;
+}
+
+.link-button {
+  background: none;
+  border: none;
+  color: #2563eb;
+  font-weight: 600;
+  cursor: pointer;
+  text-decoration: underline;
+}
+
+.link-button:hover {
+  color: #1e40af;
+}
+
+.mini-building {
+  height: 280px;
+  border-radius: 16px;
+  overflow: hidden;
+  background: linear-gradient(135deg, rgba(148, 163, 184, 0.35), rgba(96, 165, 250, 0.15));
+}
+
+.tree-section {
+  flex: 1;
+}
+
+.tree-section h3 {
+  margin: 0 0 0.5rem 0;
+}
+
+@media (max-width: 1200px) {
+  .building-selection {
+    grid-template-columns: 1fr;
+    padding: 2rem;
+    gap: 1.5rem;
+  }
+
+  .selection-canvas {
+    min-height: 420px;
+  }
+}
+
+@media (max-width: 960px) {
+  .main-layout {
+    height: auto;
+  }
+
+  .building-selection {
+    padding: 1.5rem;
+  }
+
+  .selection-copy h2 {
+    font-size: 1.5rem;
+  }
 }

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -4,26 +4,62 @@
   </header>
   
   <main class="main-content">
-    <p-splitter [style]="{'height': '100%'}" [panelSizes]="[25, 75]">
-      <ng-template pTemplate>
-        <div class="panel panel-left">
-          <h3>Building Structure</h3>
-          <app-tree-view 
-            [data]="buildingData"
-            [highlightedId]="highlightedId"
-            (nodeSelected)="onTreeNodeSelected($event)">
-          </app-tree-view>
+    <ng-container *ngIf="!selectedFloor; else floorWorkspace">
+      <div class="building-selection">
+        <div class="selection-copy">
+          <h2>สำรวจอาคารเรียนรวมวิศวกรรมศาสตร์</h2>
+          <p>เลือกชั้นที่ต้องการเพื่อดูแผนผัง พื้นที่ และระดับการเข้าถึงสำหรับ Visitor, Staff หรือ Blacklist</p>
+          <button type="button" *ngIf="selectedFloorIndex !== null" (click)="resetToBuildingOverview()">รีเซ็ตมุมมอง</button>
         </div>
-      </ng-template>
-      <ng-template pTemplate>
-        <div class="panel panel-right">
-          <app-floor-plan 
-            [floorData]="buildingData.floors[0]"
-            [panToTarget]="selectedNodeData"
-            (zoneChanged)="onZoneChanged($event)">
-          </app-floor-plan>
+        <div class="selection-canvas">
+          <app-building-view
+            [floors]="buildingData.floors"
+            (floorSelected)="onFloorSelected($event)">
+          </app-building-view>
         </div>
-      </ng-template>
-    </p-splitter>
+      </div>
+    </ng-container>
+
+    <ng-template #floorWorkspace>
+      <p-splitter [style]="{'height': '100%'}" [panelSizes]="[32, 68]">
+        <ng-template pTemplate>
+          <div class="panel panel-left">
+            <div class="panel-section">
+              <div class="panel-section__header">
+                <div>
+                  <h3>{{ buildingData.buildingName }}</h3>
+                  <p class="panel-section__subtitle">ชั้น {{ selectedFloor?.floor }}</p>
+                </div>
+                <button type="button" class="link-button" (click)="resetToBuildingOverview()">กลับไปดูอาคาร</button>
+              </div>
+              <div class="mini-building">
+                <app-building-view
+                  [floors]="buildingData.floors"
+                  [activeFloor]="selectedFloor?.floor ?? null"
+                  (floorSelected)="onFloorSelected($event)">
+                </app-building-view>
+              </div>
+            </div>
+            <div class="panel-section tree-section">
+              <h3>Zone Directory</h3>
+              <app-tree-view
+                [data]="buildingData"
+                [highlightedId]="highlightedId"
+                (nodeSelected)="onTreeNodeSelected($event)">
+              </app-tree-view>
+            </div>
+          </div>
+        </ng-template>
+        <ng-template pTemplate>
+          <div class="panel panel-right">
+            <app-floor-plan
+              [floorData]="selectedFloor"
+              [panToTarget]="selectedNodeData"
+              (zoneChanged)="onZoneChanged($event)">
+            </app-floor-plan>
+          </div>
+        </ng-template>
+      </p-splitter>
+    </ng-template>
   </main>
 </div>

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -4,12 +4,13 @@ import { FloorPlanComponent } from "./components/floor-plan/floor-plan.component
 import { TreeViewComponent } from './components/tree-view/tree-view.component';
 import { ButtonModule } from 'primeng/button';
 import { SplitterModule } from 'primeng/splitter';
+import { BuildingViewComponent } from './components/building-view/building-view.component';
 import floorData from './components/floor-plan/e12-floor1.json';
 
 @Component({
   selector: 'app-root',
   standalone: true,
-  imports: [ CommonModule, FloorPlanComponent, TreeViewComponent, ButtonModule, SplitterModule ],
+  imports: [ CommonModule, FloorPlanComponent, TreeViewComponent, BuildingViewComponent, ButtonModule, SplitterModule ],
   templateUrl: './app.component.html',
   styleUrls: ['./app.component.css']
 })
@@ -17,12 +18,129 @@ export class App {
   buildingData: any = floorData;
   highlightedId: string | null = null;
   selectedNodeData: any = null;
+  selectedFloorIndex: number | null = null;
+  private readonly totalFloors = 12;
+  private readonly floorPalette = [
+    '#f94144', '#f3722c', '#f8961e', '#f9844a', '#f9c74f', '#90be6d',
+    '#43aa8b', '#4d908e', '#577590', '#277da1', '#a855f7', '#ef476f'
+  ];
+
+  constructor() {
+    this.initialiseFloors();
+  }
 
   onZoneChanged(id: string | null): void {
     this.highlightedId = id;
   }
 
   onTreeNodeSelected(data: any): void {
-    this.selectedNodeData = data;
+    if (data?.floor && this.selectedFloor?.floor !== data.floor) {
+      this.onFloorSelected(data.floor);
+    }
+    if (data?.boundary || data?.center) {
+      this.selectedNodeData = data;
+    } else {
+      this.selectedNodeData = null;
+    }
+  }
+
+  onFloorSelected(floorNumber: number): void {
+    const index = this.buildingData.floors.findIndex((f: any) => f.floor === floorNumber);
+    if (index === -1) return;
+    this.selectedFloorIndex = index;
+    this.highlightedId = null;
+    this.selectedNodeData = null;
+  }
+
+  resetToBuildingOverview(): void {
+    this.selectedFloorIndex = null;
+    this.selectedNodeData = null;
+    this.highlightedId = null;
+  }
+
+  get selectedFloor(): any | null {
+    if (this.selectedFloorIndex === null) return null;
+    return this.buildingData.floors[this.selectedFloorIndex] ?? null;
+  }
+
+  private initialiseFloors(): void {
+    if (!this.buildingData?.floors) {
+      this.buildingData = { buildingId: 'E12', buildingName: 'E12 Engineering Building', floors: [] };
+    }
+    const baseWalls = this.buildingData.floors[0]?.walls ? this.cloneWalls(this.buildingData.floors[0].walls) : [];
+
+    this.buildingData.floors = this.buildingData.floors.map((floor: any, index: number) => ({
+      ...floor,
+      color: floor.color ?? this.floorPalette[index % this.floorPalette.length]
+    }));
+
+    const existingCount = this.buildingData.floors.length;
+    for (let floorNumber = existingCount + 1; floorNumber <= this.totalFloors; floorNumber++) {
+      this.buildingData.floors.push(
+        this.createPlaceholderFloor(floorNumber, this.floorPalette[(floorNumber - 1) % this.floorPalette.length], baseWalls)
+      );
+    }
+  }
+
+  private createPlaceholderFloor(floorNumber: number, color: string, baseWalls: any[]): any {
+    const hallBoundary = { min: { x: -7, y: -9 }, max: { x: 7, y: 9 } };
+    const liftBoundary = { min: { x: -7, y: -18 }, max: { x: 7, y: -9 } };
+
+    return {
+      floor: floorNumber,
+      floorName: `ชั้น ${floorNumber}`,
+      color,
+      walls: this.cloneWalls(baseWalls),
+      zones: [
+        {
+          id: `f${floorNumber}_core_zone`,
+          name: 'Core Corridor',
+          areas: [
+            { id: `f${floorNumber}_hall`, name: `Hall ${floorNumber}`, color: '#cfe9ff', boundary: hallBoundary },
+            { id: `f${floorNumber}_lift_lobby`, name: 'Lift Lobby', color: '#b1ddff', boundary: liftBoundary }
+          ],
+          rooms: [
+            {
+              id: `f${floorNumber}_wing_left`,
+              name: `Learning Studio ${floorNumber}A`,
+              color: '#d1c4f6',
+              boundary: { min: { x: -46, y: -4 }, max: { x: -7, y: 9 } },
+              doors: [
+                {
+                  id: `f${floorNumber}_wing_left_door`,
+                  center: { x: -16.75, y: -4 },
+                  size: { width: 2, depth: 0.2 },
+                  accessLevel: 1
+                }
+              ]
+            },
+            {
+              id: `f${floorNumber}_wing_right`,
+              name: `Innovation Lab ${floorNumber}B`,
+              color: '#c3f7d6',
+              boundary: { min: { x: 7, y: -4 }, max: { x: 46, y: 9 } },
+              doors: [
+                {
+                  id: `f${floorNumber}_wing_right_door`,
+                  center: { x: 16.75, y: -4 },
+                  size: { width: 2, depth: 0.2 },
+                  accessLevel: 0
+                }
+              ]
+            }
+          ],
+          objects: [
+            { id: `f${floorNumber}_collab_hub`, type: 'Collaboration Hub', boundary: { min: { x: -4, y: -11 }, max: { x: 4, y: -9 } } }
+          ]
+        }
+      ]
+    };
+  }
+
+  private cloneWalls(walls: any[]): any[] {
+    return walls.map(wall => ({
+      start: { x: wall.start.x, y: wall.start.y },
+      end: { x: wall.end.x, y: wall.end.y }
+    }));
   }
 }

--- a/src/app/components/building-view/building-view.component.css
+++ b/src/app/components/building-view/building-view.component.css
@@ -8,4 +8,5 @@
   width: 100%;
   height: 100%;
   display: block;
+  cursor: pointer;
 }

--- a/src/app/components/floor-plan/floor-plan.component.css
+++ b/src/app/components/floor-plan/floor-plan.component.css
@@ -43,26 +43,92 @@ canvas {
   background-color: #EBF0F5;
 }
 
-.view-toggle-container {
+.floor-plan-toolbar {
   position: absolute;
-  top: 20px;
-  right: 20px;
+  top: 16px;
+  left: 24px;
+  right: 24px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 24px;
   z-index: 10;
+  pointer-events: auto;
+}
+
+.floor-indicator {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  background-color: rgba(255, 255, 255, 0.85);
+  padding: 10px 16px;
+  border-radius: 12px;
+  box-shadow: 0 4px 12px rgba(15, 23, 42, 0.12);
+}
+
+.floor-indicator__number {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 42px;
+  height: 42px;
+  border-radius: 50%;
+  background: linear-gradient(135deg, #2563eb, #38bdf8);
+  color: #ffffff;
+  font-weight: 700;
+  font-size: 1.2rem;
+}
+
+.floor-indicator__label {
+  display: flex;
+  flex-direction: column;
+  line-height: 1.2;
+}
+
+.floor-indicator__title {
+  font-weight: 700;
+  font-size: 1.05rem;
+  color: #0f172a;
+}
+
+.floor-indicator__subtitle {
+  font-size: 0.75rem;
+  color: #475569;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+}
+
+.access-terminal {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 6px;
+  background-color: rgba(15, 23, 42, 0.85);
+  padding: 10px 18px;
+  border-radius: 16px;
+  color: #e2e8f0;
+  box-shadow: 0 6px 16px rgba(15, 23, 42, 0.25);
+}
+
+.terminal-title {
+  font-size: 0.75rem;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: #94a3b8;
+}
+
+.terminal-buttons {
+  display: flex;
+  gap: 8px;
+}
+
+.view-toggle-container {
   display: flex;
   gap: 10px;
 }
 
-.auth-controls {
-  position: absolute;
-  top: 20px;
-  left: 50%;
-  transform: translateX(-50%);
-  z-index: 10;
-  display: flex;
-  gap: 10px;
-  background-color: rgba(255, 255, 255, 0.8);
-  padding: 5px;
-  border-radius: 8px;
+:host ::ng-deep .view-toggle-container .p-button {
+  white-space: nowrap;
 }
 
 .mobile-controls {
@@ -133,6 +199,28 @@ canvas {
 @media (max-width: 1023px) {
   .info-display-container {
     bottom: 140px;
+  }
+}
+
+@media (max-width: 900px) {
+  .floor-plan-toolbar {
+    flex-direction: column;
+    align-items: stretch;
+    gap: 16px;
+  }
+
+  .floor-indicator,
+  .access-terminal,
+  .view-toggle-container {
+    justify-content: center;
+  }
+
+  .access-terminal {
+    align-items: stretch;
+  }
+
+  .terminal-buttons {
+    justify-content: center;
   }
 }
 

--- a/src/app/components/floor-plan/floor-plan.component.html
+++ b/src/app/components/floor-plan/floor-plan.component.html
@@ -1,35 +1,48 @@
 <div [class.fullscreen]="isFullscreen" class="floor-plan-wrapper">
 
-  <div class="view-toggle-container" (click)="$event.stopPropagation()">
-    <p-button
-      (click)="toggleFullscreen()"
-      [icon]="isFullscreen ? 'pi pi-window-minimize' : 'pi pi-window-maximize'"
-      [label]="isFullscreen ? 'Exit' : 'Fullscreen'"
-      styleClass="p-button-sm"
-    ></p-button>
-    <p-button
-      (click)="toggleView()"
-      [label]="currentView === 'game' ? 'Top View' : 'Game View'"
-      styleClass="p-button-sm p-button-secondary"
-    ></p-button>
-  </div>
+  <div class="floor-plan-toolbar" (click)="$event.stopPropagation()">
+    <div class="floor-indicator" *ngIf="floorData">
+      <span class="floor-indicator__number">{{ floorData.floor }}</span>
+      <div class="floor-indicator__label">
+        <span class="floor-indicator__title">{{ floorData.floorName }}</span>
+        <span class="floor-indicator__subtitle">E12 Engineering Hub</span>
+      </div>
+    </div>
 
-  <div class="auth-controls" (click)="$event.stopPropagation()">
-    <p-button
-      (click)="simulateAuthentication(1)"
-      label="Guest Access"
-      styleClass="p-button-sm p-button-info"
-    ></p-button>
-    <p-button
-      (click)="simulateAuthentication(2)"
-      label="Staff Access"
-      styleClass="p-button-sm p-button-success"
-    ></p-button>
-    <p-button
-      (click)="simulateAuthentication(0)"
-      label="Logout"
-      styleClass="p-button-sm p-button-warning"
-    ></p-button>
+    <div class="access-terminal">
+      <span class="terminal-title">Face Access</span>
+      <div class="terminal-buttons">
+        <p-button
+          (click)="simulateAuthentication(-1)"
+          label="-1"
+          styleClass="p-button-sm p-button-danger"
+        ></p-button>
+        <p-button
+          (click)="simulateAuthentication(0)"
+          label="0"
+          styleClass="p-button-sm p-button-secondary"
+        ></p-button>
+        <p-button
+          (click)="simulateAuthentication(1)"
+          label="1"
+          styleClass="p-button-sm p-button-success"
+        ></p-button>
+      </div>
+    </div>
+
+    <div class="view-toggle-container">
+      <p-button
+        (click)="toggleView()"
+        [label]="currentView === 'iso' ? 'Top View' : 'ISO View'"
+        styleClass="p-button-sm p-button-secondary"
+      ></p-button>
+      <p-button
+        (click)="toggleFullscreen()"
+        [icon]="isFullscreen ? 'pi pi-window-minimize' : 'pi pi-window-maximize'"
+        [label]="isFullscreen ? 'Exit' : 'Fullscreen'"
+        styleClass="p-button-sm"
+      ></p-button>
+    </div>
   </div>
 
   <canvas #canvas></canvas>

--- a/src/app/components/tree-view/tree-view.component.css
+++ b/src/app/components/tree-view/tree-view.component.css
@@ -1,0 +1,65 @@
+.tree-view-container {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.tree-search {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.tree-search input[type="search"] {
+  flex: 1;
+  padding: 0.5rem 0.75rem;
+  border: 1px solid #cbd5e1;
+  border-radius: 0.75rem;
+  font-size: 0.95rem;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.tree-search input[type="search"]:focus {
+  border-color: #2563eb;
+  outline: none;
+  box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.25);
+}
+
+.tree-search button {
+  padding: 0.5rem 1rem;
+  border: none;
+  border-radius: 0.75rem;
+  background: linear-gradient(135deg, #2563eb, #38bdf8);
+  color: #ffffff;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+
+.tree-search button:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 6px 14px rgba(37, 99, 235, 0.25);
+}
+
+.tree-search button:active {
+  transform: translateY(0);
+  box-shadow: none;
+}
+
+.search-feedback {
+  color: #ef4444;
+  font-size: 0.75rem;
+}
+
+:host ::ng-deep .p-tree {
+  border-radius: 12px;
+  border: 1px solid #e2e8f0;
+  padding: 0.5rem 0.75rem;
+  background: rgba(255, 255, 255, 0.85);
+  box-shadow: inset 0 1px 0 rgba(148, 163, 184, 0.2);
+}
+
+:host ::ng-deep .p-treenode .p-treenode-content.p-highlight {
+  background: rgba(59, 130, 246, 0.15);
+  color: #1d4ed8;
+  font-weight: 600;
+}

--- a/src/app/components/tree-view/tree-view.component.html
+++ b/src/app/components/tree-view/tree-view.component.html
@@ -1,8 +1,21 @@
-<p-tree 
-  #tree
-  [value]="treeData" 
-  selectionMode="single" 
-  [(selection)]="selectedNode"
-  (onNodeSelect)="onNodeSelect($event)"
-  styleClass="w-full md:w-30rem">
-</p-tree>
+<div class="tree-view-container">
+  <div class="tree-search">
+    <input
+      type="search"
+      [(ngModel)]="searchTerm"
+      (keydown)="onSearchKeydown($event)"
+      placeholder="ค้นหาห้อง โซน หรือประตู"
+      aria-label="ค้นหารายการในอาคาร"
+    />
+    <button type="button" (click)="onSearch()">Search</button>
+  </div>
+  <small *ngIf="notFound" class="search-feedback">ไม่พบผลลัพธ์ที่ตรงกับ "{{ searchTerm }}"</small>
+  <p-tree
+    #tree
+    [value]="treeData"
+    selectionMode="single"
+    [(selection)]="selectedNode"
+    (onNodeSelect)="onNodeSelect($event)"
+    styleClass="w-full md:w-30rem">
+  </p-tree>
+</div>

--- a/src/app/components/tree-view/tree-view.component.ts
+++ b/src/app/components/tree-view/tree-view.component.ts
@@ -1,12 +1,13 @@
 import { Component, Input, Output, EventEmitter, OnChanges, SimpleChanges, ViewChild } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
 import { Tree, TreeModule } from 'primeng/tree';
 import { TreeNode } from 'primeng/api';
 
 @Component({
   selector: 'app-tree-view',
   standalone: true,
-  imports: [CommonModule, TreeModule],
+  imports: [CommonModule, FormsModule, TreeModule],
   templateUrl: './tree-view.component.html',
   styleUrls: ['./tree-view.component.css']
 })
@@ -18,13 +19,19 @@ export class TreeViewComponent implements OnChanges {
 
   treeData: TreeNode[] = [];
   selectedNode: TreeNode | null = null;
+  searchTerm = '';
+  notFound = false;
 
   ngOnChanges(changes: SimpleChanges): void {
     if (changes['data'] && this.data) {
       this.treeData = this.transformDataToTreeNodes(this.data);
     }
     if (changes['highlightedId'] && this.treeData.length > 0) {
-      this.expandAndSelectNodeByKey(this.treeData, this.highlightedId);
+      this.notFound = false;
+      const found = this.expandAndSelectNodeByKey(this.treeData, this.highlightedId);
+      if (!found) {
+        this.selectNode(null);
+      }
     }
   }
 
@@ -37,26 +44,27 @@ export class TreeViewComponent implements OnChanges {
         children: buildingData.floors.map((floor: any) => ({
           key: `floor_${floor.floor}`,
           label: floor.floorName,
+          data: { type: 'floor', floor: floor.floor },
           expanded: true,
           children: floor.zones.map((zone: any) => ({
             key: zone.id,
             label: zone.name,
-            data: { type: 'zone', ...zone },
+            data: { type: 'zone', floor: floor.floor, ...zone },
             children: [
               ...zone.areas.map((area: any) => ({
                 key: area.id,
                 label: area.name,
-                data: { type: 'area', ...area },
+                data: { type: 'area', floor: floor.floor, ...area },
                 icon: 'pi pi-map-marker'
               })),
               ...zone.rooms.map((room: any) => ({
                 key: room.id,
                 label: room.name,
-                data: { type: 'room', ...room },
+                data: { type: 'room', floor: floor.floor, ...room },
                 children: room.doors.map((door: any) => ({
                   key: door.id,
                   label: `Door: ${door.id}`,
-                  data: { type: 'door', ...door },
+                  data: { type: 'door', floor: floor.floor, ...door },
                   icon: 'pi pi-lock'
                 }))
               }))
@@ -66,28 +74,56 @@ export class TreeViewComponent implements OnChanges {
       }
     ];
   }
-  
+
   onNodeSelect(event: {node: TreeNode}) {
     if (event.node && event.node.data) {
       this.nodeSelected.emit(event.node.data);
     }
   }
 
-  private expandAndSelectNodeByKey(nodes: TreeNode[], key: string | null): void {
-    if (!key) {
-      this.selectedNode = null;
+  onSearch(): void {
+    this.notFound = false;
+    const trimmed = this.searchTerm.trim();
+    if (!trimmed) {
       return;
+    }
+    const match = this.findNodeByLabel(this.treeData, trimmed.toLowerCase());
+    if (match) {
+      this.selectNode(match);
+      this.expandParents(this.treeData, match);
+      this.nodeSelected.emit(match.data);
+    } else {
+      this.notFound = true;
+    }
+  }
+
+  onSearchKeydown(event: KeyboardEvent): void {
+    if (event.key === 'Enter') {
+      event.preventDefault();
+      this.onSearch();
+    }
+  }
+
+  private expandAndSelectNodeByKey(nodes: TreeNode[], key: string | null): boolean {
+    if (!key) {
+      this.selectNode(null);
+      return false;
     }
     for (const node of nodes) {
       if (node.key === key) {
-        this.selectedNode = node;
+        this.selectNode(node);
         this.expandParents(this.treeData, node);
-        return;
+        return true;
       }
       if (node.children) {
-        this.expandAndSelectNodeByKey(node.children, key);
+        const found = this.expandAndSelectNodeByKey(node.children, key);
+        if (found) {
+          node.expanded = true;
+          return true;
+        }
       }
     }
+    return false;
   }
 
   private expandParents(nodes: TreeNode[], selectedNode: TreeNode): boolean {
@@ -103,5 +139,28 @@ export class TreeViewComponent implements OnChanges {
         }
     }
     return false;
+  }
+
+  private selectNode(node: TreeNode | null): void {
+    this.selectedNode = node;
+    if (this.tree) {
+      this.tree.selection = node;
+    }
+  }
+
+  private findNodeByLabel(nodes: TreeNode[], query: string): TreeNode | null {
+    for (const node of nodes) {
+      if (node.label?.toLowerCase().includes(query)) {
+        return node;
+      }
+      if (node.children) {
+        const childMatch = this.findNodeByLabel(node.children, query);
+        if (childMatch) {
+          node.expanded = true;
+          return childMatch;
+        }
+      }
+    }
+    return null;
   }
 }


### PR DESCRIPTION
## Summary
- introduce a building selection stage with color-coded floor overlays and placeholder data so visitors can explore all 12 levels
- modernize the floor plan HUD with floor indicators, ISO/top toggles, and access simulation buttons for levels -1/0/1
- add a searchable tree view directory and disable Angular CLI analytics to streamline developer experience

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e764739f8c8323802dc6bd3ce9aad6