### PR TITLE
Fix floor plan ground color when selecting floors

### DIFF
--- a/src/app/components/floor-plan/floor-plan.component.ts
+++ b/src/app/components/floor-plan/floor-plan.component.ts
@@ -74,15 +74,16 @@ export class FloorPlanComponent implements AfterViewInit, OnChanges {
   ) {}
 
   ngOnChanges(changes: SimpleChanges): void {
-  if (this.isInitialized && changes['floorData'] && this.floorData) {
-    this.reloadFloorPlan();
-  }
-  if (this.isInitialized && changes['panToTarget']) {
-    const selection = changes['panToTarget'].currentValue;
-    if (selection) {
-      this.warpPlayerTo(selection)
-      this.panCameraToObject(selection);
-      this.ngZone.run(() => this.closeDetail());
+    if (this.isInitialized && changes['floorData'] && this.floorData) {
+      this.applyFloorColor();
+      this.reloadFloorPlan();
+    }
+    if (this.isInitialized && changes['panToTarget']) {
+      const selection = changes['panToTarget'].currentValue;
+      if (selection) {
+        this.warpPlayerTo(selection);
+        this.panCameraToObject(selection);
+        this.ngZone.run(() => this.closeDetail());
       }
     }
   }
@@ -92,6 +93,7 @@ export class FloorPlanComponent implements AfterViewInit, OnChanges {
     this.isInitialized = true;
     
     this.createScene();
+    this.applyFloorColor();
     this.loadFloorPlan();
     this.createPlayer();
     this.startRenderingLoop();
@@ -562,8 +564,19 @@ export class FloorPlanComponent implements AfterViewInit, OnChanges {
     }
     this.updateDoorMaterials();
 
-    if (this.coloredGroundPlane && this.floorData?.color) {
-      (this.coloredGroundPlane.material as THREE.MeshStandardMaterial).color.set(this.floorData.color);
+    this.applyFloorColor();
+  }
+
+  private applyFloorColor(): void {
+    if (!this.coloredGroundPlane) {
+      return;
+    }
+
+    const material = this.coloredGroundPlane.material as THREE.MeshStandardMaterial;
+    if (this.floorData?.color) {
+      material.color.set(this.floorData.color);
+    } else {
+      material.color.set(0xeeeeee);
     }
   }
 


### PR DESCRIPTION
## Summary
- ensure the floor plan ground updates its color whenever the selected floor changes
- reuse a helper to apply the building-view floor color on initialization and reload

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ee898f41748323a21e400d0ff50b48